### PR TITLE
Add strings for Sony Tablet S and Sony Tablet P support

### DIFF
--- a/usb_driver/android_winusb.inf
+++ b/usb_driver/android_winusb.inf
@@ -817,9 +817,9 @@ HKR,,Icon,,-1
 %MotCompositeInterface% = motandroidusb.Dev, USB\VID_22B8&PID_2D68&MI_01
 
 ;SONY Sony Tablet P 
-%CompositeAdbInterface%&nbsp;&nbsp;&nbsp;&nbsp; = USB_Install, USB\VID_054C&PID_04D2&MI_01 
+%CompositeAdbInterface%     = USB_Install, USB\VID_054C&PID_04D2&MI_01 
 ;SONY Sony Tablet S 
-%CompositeAdbInterface%&nbsp;&nbsp;&nbsp;&nbsp; = USB_Install, USB\VID_054C&PID_05B4&MI_01
+%CompositeAdbInterface%     = USB_Install, USB\VID_054C&PID_05B4&MI_01
 
 
 [ClockworkMod.NTamd64]
@@ -1615,9 +1615,9 @@ HKR,,Icon,,-1
 %MotCompositeInterface% = motandroidusb.Dev, USB\VID_22B8&PID_2D68&MI_01
 
 ;SONY Sony Tablet P 
-%CompositeAdbInterface%&nbsp;&nbsp;&nbsp;&nbsp; = USB_Install, USB\VID_054C&PID_04D2&MI_01 
+%CompositeAdbInterface%     = USB_Install, USB\VID_054C&PID_04D2&MI_01 
 ;SONY Sony Tablet S 
-%CompositeAdbInterface%&nbsp;&nbsp;&nbsp;&nbsp; = USB_Install, USB\VID_054C&PID_05B4&MI_01
+%CompositeAdbInterface%     = USB_Install, USB\VID_054C&PID_05B4&MI_01
 
 
 [USB_Install]


### PR DESCRIPTION
As per the subject line, here are the strings to add ADB support for Sony Tablet S and Sony Tablet P.
