### PR TITLE
add entry for ADB in Recovery - Samsung D2

### DIFF
--- a/usb_driver/android_winusb.inf
+++ b/usb_driver/android_winusb.inf
@@ -65,6 +65,7 @@ HKR,,Icon,,-1
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_685E&REV_0400&MI_03
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_6866&REV_0228&MI_01
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_6860&REV_0400&MI_03
+%Samsung%     = USB_Install_17, USB\VID_04E8&PID_6860&REV_0228
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_6866&REV_0226&MI_01
 
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_685D&ADB
@@ -899,6 +900,7 @@ HKR,,Icon,,-1
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_685E&REV_0400&MI_03
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_6866&REV_0228&MI_01
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_6860&REV_0400&MI_03
+%Samsung%     = USB_Install_17, USB\VID_04E8&PID_6860&REV_0228
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_6866&REV_0226&MI_01
 
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_685D&ADB


### PR DESCRIPTION
added:
%Samsung%     = USB_Install_17, USB\VID_04E8&PID_6860&REV_0228
