### PR TITLE
Update android_winusb.inf , add compatible ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@ A single Windows driver that supports the ADB (and fastboot) interface for most 
 
 
 [Download Windows Installer](http://download.clockworkmod.com/test/UniversalAdbDriverSetup.msi)
+
+本项目是从其他项目fork过来的，他的做法是把各种手机型号的 硬件ID写进.inf这样做会使 .inf非常庞大，并且并不能保证全面。
+%Samsung%     = USB_Install_17, USB\VID_04E8&PID_685E&REV_0400&MI_03
+%Samsung%     = USB_Install_17, USB\VID_04E8&PID_6866&REV_0228&MI_01
+
+
+Adb 驱动本身就是能用的，不同的设备的区别在于 .inf 文件中的 VID 和PID 以及接口不同，如果你使用compatible ID 的话就可以把驱动变成通用驱动。
+如下所示：
+
+%CompositeAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_01
+%SingleAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_03
+
+这样做存在的不足是，在用inf2cat.exe 从inf生成cat的时候，会出错，但是有一个工具可以完成。
+亚信数字签名：http://www.trustasia.com/solutions/signtools/ 
+需要导入证书 并添加证书规则才可以使用。
+
+生成证书参考：
+http://www.cnblogs.com/bearhb/archive/2012/07/03/2574206.html
+

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A single Windows driver that supports the ADB (and fastboot) interface for most 
 %Samsung%     = USB_Install_17, USB\VID_04E8&PID_6866&REV_0228&MI_01
 
 
-Adb 驱动本身就是能用的，不同的设备的区别在于 .inf 文件中的 VID 和PID 以及接口不同，如果你使用compatible ID 的话就可以把驱动变成通用驱动。
+Adb 驱动本身就是通用的，不同的设备的区别在于 .inf 文件中的 VID 和PID 以及接口不同，如果你使用compatible ID 的话就可以把驱动变成通用驱动。
 如下所示：
 
 %CompositeAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_01  

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A single Windows driver that supports the ADB (and fastboot) interface for most 
 Adb 驱动本身就是能用的，不同的设备的区别在于 .inf 文件中的 VID 和PID 以及接口不同，如果你使用compatible ID 的话就可以把驱动变成通用驱动。
 如下所示：
 
-%CompositeAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_01
+%CompositeAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_01  
 %SingleAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_03
 
 这样做存在的不足是，在用inf2cat.exe 从inf生成cat的时候，会出错，但是有一个工具可以完成。

--- a/usb_driver/android_winusb.inf
+++ b/usb_driver/android_winusb.inf
@@ -874,6 +874,11 @@ HKR,,Icon,,-1
 %ZteValet%	= USB_Install, USB\VID_19D2&PID_0310&REV_0233&MI_01
 %ZteValet%	= USB_Install, USB\VID_19D2&PID_0310&MI_01
 
+;If there is no suitable configuration up here, compatible ID is also useable
+%CompositeAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_01
+%SingleAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_03
+
+
 [ClockworkMod.NTamd64]
 
 ;Nook
@@ -1726,6 +1731,10 @@ HKR,,Icon,,-1
 ;ZTE Valet
 %ZteValet%	= USB_Install, USB\VID_19D2&PID_0310&REV_0233&MI_01
 %ZteValet%	= USB_Install, USB\VID_19D2&PID_0310&MI_01
+
+;If there is no suitable configuration up here, compatible ID is also useable
+%CompositeAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_01
+%SingleAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_03
 
 
 [USB_Install]


### PR DESCRIPTION
If there is no suitable configuration up here, compatible ID is also useable.

%CompositeAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_01
%SingleAdbInterface% = USB_Install, USB\Class_FF&SubClass_42&Prot_03

You can get some information from http://msdn.microsoft.com/en-us/library/windows/hardware/ff728853(v=vs.85).aspx

The adb interface is always defined as USB\Class_FF&SubClass_42&Prot_01 in adb.h as follow:
# define ADB_CLASS              0xff
# define ADB_SUBCLASS           0x42
# define ADB_PROTOCOL           0x1

see https://github.com/jcs/adb/blob/master/adb.h#L436
